### PR TITLE
Allow for retries of RHSM subcription

### DIFF
--- a/roles/openshift.prereq/tasks/rhsm.yml
+++ b/roles/openshift.prereq/tasks/rhsm.yml
@@ -17,7 +17,11 @@
   with_items: "{{ rhel_rhsm_plugins }}"
 
 - name: Register with RHSM
-  redhat_subscription: state=present activationkey='{{ rhel_rhsm_activationkey }}' org_id='{{ rhel_rhsm_org_id }}'
+  shell: subscription-manager register --org={{ rhel_rhsm_org_id }} --activationkey={{ rhel_rhsm_activationkey }}
+  register: result
+  retries: 10
+  delay: 30
+  until: result.rc == 0
 
 - name: Disable all RHSM repositories
   shell: subscription-manager repos --disable="*"


### PR DESCRIPTION
When scaling to 6 or more nodes, this fixes the rhsm subscription registration initial failures and allows for a retry of the rhsm subscription registration.